### PR TITLE
Fix a syntax warning

### DIFF
--- a/UltiSnips/asciidoc.snippets
+++ b/UltiSnips/asciidoc.snippets
@@ -17,7 +17,7 @@
 
 global !p
 whitespace = re.compile(r'[\s_-]*\{nbsp\}[\s_-]*|[\s_-]+')
-macros     = re.compile(r'\\bbtn:\[|\\bkbd:\[|\\bmenu:\\b|\[[^\]]*\][\*_`#]|\{[^\}]*\}[\s_]*')
+macros     = re.compile(r'\bbtn:\[|\bkbd:\[|\bmenu:\b|\[[^\]]*\][\*_`#]|\{[^\}]*\}[\s_]*')
 disallowed = re.compile(r'[^\w\d.-]')
 
 def compose_id(string):

--- a/UltiSnips/asciidoc.snippets
+++ b/UltiSnips/asciidoc.snippets
@@ -16,9 +16,9 @@
 #   [3] https://github.com/redhat-documentation/modular-docs
 
 global !p
-whitespace = re.compile('[\s_-]*\{nbsp\}[\s_-]*|[\s_-]+')
-macros     = re.compile('\\bbtn:\[|\\bkbd:\[|\\bmenu:\\b|\[[^\]]*\][\*_`#]|\{[^\}]*\}[\s_]*')
-disallowed = re.compile('[^\w\d.-]')
+whitespace = re.compile(r'[\s_-]*\{nbsp\}[\s_-]*|[\s_-]+')
+macros     = re.compile(r'\\bbtn:\[|\\bkbd:\[|\\bmenu:\\b|\[[^\]]*\][\*_`#]|\{[^\}]*\}[\s_]*')
+disallowed = re.compile(r'[^\w\d.-]')
 
 def compose_id(string):
 	'''Converts an AsciiDoc string to a valid block ID.'''


### PR DESCRIPTION
With Python 3.12.0, the following warning was shown when you started typing in insert mode in VIM:

----
Error detected while processing TextChangedI Autocommands for "*"..function UltiSnips#TrackChange:
line    1:
<global-snippets>:2: SyntaxWarning: invalid escape sequence '\s'
----

This patch fixes the problem.